### PR TITLE
MWPW-175506: Insufficient color contrast ratio for character counter

### DIFF
--- a/acrobat/blocks/rnr/rnr.css
+++ b/acrobat/blocks/rnr/rnr.css
@@ -125,9 +125,11 @@
 }
 
 .rnr-comments-character-counter {
-  color: var(--color-gray-400);
+
+  color: #767676;
   font-size: 14px;
   font-variant-numeric: tabular-nums;
+
 }
 
 .rnr-summary-container {


### PR DESCRIPTION
## Summary
- Fixed: Character counter color contrast issue in RNR comments
- Change: Updated .rnr-comments-character-counter color from #B6B6B6 to #767676
- Impact: Meets WCAG AA color contrast requirements (4.5:1 ratio)

## Details
- **Element**: `<span class="rnr-comments-character-counter">500 / 500</span>`
- **Before**: #B6B6B6 (2:1 contrast ratio)
- **After**: #767676 (4.5:1+ contrast ratio)
- **WCAG**: 1.4.3 Contrast (Minimum) Level AA

## Testing
- [ ] Verified fix addresses ticket contrast issue
- [ ] Character counter text is now readable
- [ ] No visual regressions in RNR block
- [ ] Maintains consistent styling

## Related
- Jira: MWPW-175506