### PR TITLE
MWPW-175506: Insufficient color contrast ratio for character counter

### DIFF
--- a/acrobat/blocks/rnr/rnr.css
+++ b/acrobat/blocks/rnr/rnr.css
@@ -125,9 +125,11 @@
 }
 
 .rnr-comments-character-counter {
-  color: var(--color-gray-400);
+
+  color: #767676;
   font-size: 14px;
   font-variant-numeric: tabular-nums;
+
 }
 
 .rnr-summary-container {


### PR DESCRIPTION
## Summary
- Fixed: Character counter color contrast issue in RNR block
- Change: Updated `.rnr-comments-character-counter` color from `var(--color-gray-400)` (#B6B6B6) to `#767676`
- Result: Improved contrast ratio from 2:1 to 4.5:1 (meets WCAG AA requirements)

## Testing
- [ ] Verified character counter now meets 4.5:1 contrast ratio
- [ ] No visual regressions in RNR block
- [ ] Color change preserves design intent

## Related
- Jira: MWPW-175506
- WCAG: 1.4.3 Contrast (Minimum) (Level AA)