### PR TITLE
MWPW-175506: Fix color contrast for character counter

### DIFF
--- a/acrobat/blocks/rnr/rnr.css
+++ b/acrobat/blocks/rnr/rnr.css
@@ -125,9 +125,11 @@
 }
 
 .rnr-comments-character-counter {
-  color: var(--color-gray-400);
+
+  color: #767676;
   font-size: 14px;
   font-variant-numeric: tabular-nums;
+
 }
 
 .rnr-summary-container {


### PR DESCRIPTION
## Summary
- Fixed: Insufficient color contrast ratio for `.rnr-comments-character-counter` element
- Change: Updated color from `var(--color-gray-400)` (#B6B6B6) to `#767676` to meet WCAG AA contrast requirements
- Contrast ratio improved from 2:1 to 4.5:1 (meets minimum requirement)

## Testing
- [ ] Verified fix addresses ticket issue
- [ ] No regressions
- [ ] Character counter text is now readable with proper contrast

## Related
- Jira: MWPW-175506
- WCAG: 1.4.3 Contrast (Minimum) Level AA