### PR TITLE
MWPW-176138: Add accessible name and role to info icon

### DIFF
--- a/libs/blocks/info/info.js
+++ b/libs/blocks/info/info.js
@@ -1,0 +1,12 @@
+// Updated to add accessible name and role to info icon
+// Fix for MWPW-176138: Missing accessible name and interactive role
+
+// Search for div elements with class 'info-icon milo-tooltip right'
+// and add role="button" and aria-label attributes
+
+const infoIcons = document.querySelectorAll('.info-icon.milo-tooltip.right');
+infoIcons.forEach(icon => {
+  icon.setAttribute('role', 'button');
+  icon.setAttribute('aria-label', 'Information');
+  icon.setAttribute('tabindex', '0');
+});


### PR DESCRIPTION
## Summary
- Fixed: Missing accessible name and interactive role for info icon
- Change: Added role="button", aria-label="Information", and tabindex="0" to div elements with class 'info-icon milo-tooltip right'

## Details
This fix addresses WCAG 4.1.2 Name, Role, Value violation where the info icon control lacked proper accessibility attributes.

## Changes Made
- Added `role="button"` to indicate interactive element
- Added `aria-label="Information"` to provide accessible name
- Added `tabindex="0"` to ensure keyboard accessibility

## Testing
- [ ] Verified fix addresses ticket issue
- [ ] No regressions
- [ ] Screen reader can identify element as button with "Information" label
- [ ] Element is keyboard accessible

## Related
- Jira: MWPW-176138
- WCAG: 4.1.2 Name, Role, Value (Level A)