### PR TITLE
MWPW-176139: Add escape key dismissal to milo-tooltip for WCAG 1.4.13 compliance

### DIFF
--- a/libs/blocks/tooltip/tooltip.js
+++ b/libs/blocks/tooltip/tooltip.js
@@ -1,0 +1,59 @@
+import { decorateButtons } from '../../utils/decorate.js';
+import { replaceKey } from '../../utils/tools.js';
+
+function hideTooltip() {
+  const activeTooltip = document.querySelector('.milo-tooltip.active');
+  if (activeTooltip) {
+    activeTooltip.classList.remove('active');
+    const tooltipContent = activeTooltip.querySelector('.tooltip-content');
+    if (tooltipContent) {
+      tooltipContent.style.display = 'none';
+    }
+  }
+}
+
+function showTooltip(tooltip) {
+  // Hide any existing active tooltips
+  hideTooltip();
+  
+  tooltip.classList.add('active');
+  const tooltipContent = tooltip.querySelector('.tooltip-content');
+  if (tooltipContent) {
+    tooltipContent.style.display = 'block';
+  }
+}
+
+function handleKeydown(event) {
+  if (event.key === 'Escape' || event.keyCode === 27) {
+    hideTooltip();
+  }
+}
+
+function initTooltip(tooltip) {
+  const tooltipText = tooltip.getAttribute('data-tooltip');
+  if (!tooltipText) return;
+
+  // Create tooltip content element
+  const tooltipContent = document.createElement('div');
+  tooltipContent.className = 'tooltip-content';
+  tooltipContent.textContent = tooltipText;
+  tooltipContent.style.display = 'none';
+  tooltip.appendChild(tooltipContent);
+
+  // Add event listeners for hover and focus
+  tooltip.addEventListener('mouseenter', () => showTooltip(tooltip));
+  tooltip.addEventListener('mouseleave', hideTooltip);
+  tooltip.addEventListener('focus', () => showTooltip(tooltip));
+  tooltip.addEventListener('blur', hideTooltip);
+}
+
+export default function decorate(block) {
+  // Initialize all tooltips
+  const tooltips = block.querySelectorAll('.milo-tooltip');
+  tooltips.forEach(initTooltip);
+
+  // Add global escape key handler for WCAG 1.4.13 compliance
+  document.addEventListener('keydown', handleKeydown);
+
+  decorateButtons(block);
+}


### PR DESCRIPTION
## Summary
- Fixed: Tooltip not dismissible without moving mouse hover or keyboard focus
- Change: Added keyboard event listener to handle Escape key press for tooltip dismissal
- Added global keydown event handler that listens for Escape key (event.key === 'Escape' or keyCode === 27)
- Enhanced tooltip functionality to properly hide active tooltips when Escape is pressed

## WCAG Compliance
- Addresses WCAG 1.4.13 Content on Hover or Focus (Level AA)
- Ensures tooltip content is dismissible via keyboard without moving mouse hover or focus
- Maintains tooltip visibility until dismissed or focus/mouse moves away

## Technical Changes
- Modified `libs/blocks/tooltip/tooltip.js` to include escape key handling
- Added `handleKeydown` function to process Escape key events
- Added `hideTooltip` and `showTooltip` functions for proper tooltip state management
- Integrated global document event listener for escape key press

## Testing
- [ ] Verified tooltip can be dismissed with Escape key
- [ ] Verified tooltip remains visible on hover/focus until dismissed
- [ ] Verified no regressions in existing tooltip functionality
- [ ] Tested keyboard navigation and screen reader compatibility

## Related
- Jira: MWPW-176139