### PR TITLE
MWPW-176136: Make info icon tooltip keyboard accessible

### DIFF
--- a/libs/blocks/tooltip/tooltip.css
+++ b/libs/blocks/tooltip/tooltip.css
@@ -1,0 +1,72 @@
+.milo-tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.milo-tooltip .info-icon {
+  cursor: pointer;
+  outline: none;
+  border-radius: 2px;
+  transition: all 0.2s ease;
+}
+
+.milo-tooltip .info-icon:focus {
+  outline: 2px solid #0066cc;
+  outline-offset: 2px;
+}
+
+.milo-tooltip .info-icon:hover,
+.milo-tooltip .info-icon:focus {
+  opacity: 0.8;
+}
+
+.milo-tooltip .tooltip-content {
+  visibility: hidden;
+  opacity: 0;
+  position: absolute;
+  z-index: 1000;
+  background-color: #333;
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+  line-height: 1.4;
+  max-width: 200px;
+  word-wrap: break-word;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+.milo-tooltip.right .tooltip-content {
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-left: 8px;
+}
+
+.milo-tooltip.right .tooltip-content::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: -5px;
+  transform: translateY(-50%);
+  border: 5px solid transparent;
+  border-right-color: #333;
+}
+
+.milo-tooltip.active .tooltip-content {
+  visibility: visible;
+  opacity: 1;
+}
+
+/* Ensure tooltips are accessible to screen readers */
+.milo-tooltip .tooltip-content {
+  white-space: nowrap;
+}
+
+.milo-tooltip .tooltip-content[aria-hidden="true"] {
+  display: none;
+}
+
+.milo-tooltip.active .tooltip-content[aria-hidden="true"] {
+  display: block;
+}

--- a/libs/blocks/tooltip/tooltip.js
+++ b/libs/blocks/tooltip/tooltip.js
@@ -1,0 +1,61 @@
+// Enhanced tooltip functionality with keyboard accessibility
+
+function initTooltip(tooltip) {
+  const trigger = tooltip.querySelector('.info-icon');
+  const content = tooltip.querySelector('.tooltip-content');
+  
+  if (!trigger || !content) return;
+  
+  // Make trigger focusable
+  trigger.setAttribute('tabindex', '0');
+  trigger.setAttribute('role', 'button');
+  trigger.setAttribute('aria-describedby', content.id || 'tooltip-content');
+  
+  // Show tooltip on hover
+  trigger.addEventListener('mouseenter', () => {
+    tooltip.classList.add('active');
+  });
+  
+  // Hide tooltip on mouse leave
+  trigger.addEventListener('mouseleave', () => {
+    tooltip.classList.remove('active');
+  });
+  
+  // Show tooltip on focus
+  trigger.addEventListener('focus', () => {
+    tooltip.classList.add('active');
+  });
+  
+  // Hide tooltip on blur
+  trigger.addEventListener('blur', () => {
+    tooltip.classList.remove('active');
+  });
+  
+  // Show/hide tooltip on Enter or Space key
+  trigger.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      tooltip.classList.toggle('active');
+    }
+    // Hide on Escape key
+    if (e.key === 'Escape') {
+      tooltip.classList.remove('active');
+      trigger.blur();
+    }
+  });
+}
+
+// Initialize all tooltips
+function initTooltips() {
+  const tooltips = document.querySelectorAll('.milo-tooltip');
+  tooltips.forEach(initTooltip);
+}
+
+// Auto-initialize when DOM is ready
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initTooltips);
+} else {
+  initTooltips();
+}
+
+export { initTooltip, initTooltips };


### PR DESCRIPTION
## Summary
- Fixed: Tooltip content for info icon not accessible via keyboard navigation
- Change: Added keyboard accessibility to div elements with class 'info-icon milo-tooltip right'

## Changes Made
- Added `tabindex='0'` to make info icons focusable
- Implemented keyboard event handlers for Enter/Space keys to show/hide tooltip
- Added focus and blur event listeners to show tooltip on focus
- Added Escape key handler to hide tooltip and remove focus
- Added proper ARIA attributes (`role='button'`, `aria-describedby`)
- Added focus styling with outline for better visibility
- Enhanced CSS to support keyboard interactions

## WCAG Compliance
- Fixes WCAG 2.1.1 Keyboard (Level A) violation
- Ensures tooltip content is accessible via keyboard navigation
- Maintains existing hover functionality while adding keyboard support

## Testing
- [ ] Verified tooltip can be accessed using Tab key
- [ ] Verified tooltip shows/hides on Enter/Space key press
- [ ] Verified tooltip shows on focus and hides on blur
- [ ] Verified Escape key hides tooltip
- [ ] Verified focus styling is visible
- [ ] Verified screen reader compatibility
- [ ] No regressions in existing hover functionality

## Related
- Jira: MWPW-176136