### PR TITLE
MWPW-176139: Add Escape key dismissal to milo-tooltip for WCAG 1.4.13 compliance

### DIFF
--- a/libs/blocks/tooltip/tooltip.css
+++ b/libs/blocks/tooltip/tooltip.css
@@ -1,0 +1,75 @@
+.tooltip-content {
+  position: absolute;
+  background: #333;
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+  max-width: 300px;
+  z-index: 1000;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  word-wrap: break-word;
+  line-height: 1.4;
+}
+
+.tooltip-content::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: -5px;
+  transform: translateY(-50%);
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid #333;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+}
+
+.milo-tooltip[data-tooltip]:hover::after,
+.milo-tooltip[data-tooltip]:focus::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-left: 10px;
+  background: #333;
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+  max-width: 300px;
+  z-index: 1000;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  word-wrap: break-word;
+  line-height: 1.4;
+  white-space: normal;
+}
+
+.milo-tooltip[data-tooltip]:hover::before,
+.milo-tooltip[data-tooltip]:focus::before {
+  content: '';
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-left: 5px;
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid #333;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  z-index: 1001;
+}
+
+/* Ensure tooltip trigger is keyboard accessible */
+.milo-tooltip[data-tooltip] {
+  cursor: pointer;
+}
+
+.milo-tooltip[data-tooltip]:focus {
+  outline: 2px solid #0066cc;
+  outline-offset: 2px;
+}

--- a/libs/blocks/tooltip/tooltip.js
+++ b/libs/blocks/tooltip/tooltip.js
@@ -1,0 +1,85 @@
+// Enhanced tooltip functionality with keyboard dismissal
+// This implementation adds Escape key support for WCAG 1.4.13 compliance
+
+function initTooltip(tooltip) {
+  const trigger = tooltip.querySelector('[data-tooltip]');
+  if (!trigger) return;
+
+  let tooltipVisible = false;
+  let tooltipElement = null;
+
+  function showTooltip() {
+    if (tooltipVisible) return;
+    
+    tooltipElement = document.createElement('div');
+    tooltipElement.className = 'tooltip-content';
+    tooltipElement.textContent = trigger.getAttribute('data-tooltip');
+    tooltipElement.setAttribute('role', 'tooltip');
+    tooltipElement.setAttribute('id', 'tooltip-' + Math.random().toString(36).substr(2, 9));
+    
+    // Position tooltip
+    const rect = trigger.getBoundingClientRect();
+    tooltipElement.style.position = 'absolute';
+    tooltipElement.style.left = (rect.left + rect.width + 10) + 'px';
+    tooltipElement.style.top = rect.top + 'px';
+    tooltipElement.style.background = '#333';
+    tooltipElement.style.color = '#fff';
+    tooltipElement.style.padding = '8px 12px';
+    tooltipElement.style.borderRadius = '4px';
+    tooltipElement.style.fontSize = '14px';
+    tooltipElement.style.maxWidth = '300px';
+    tooltipElement.style.zIndex = '1000';
+    
+    document.body.appendChild(tooltipElement);
+    trigger.setAttribute('aria-describedby', tooltipElement.id);
+    tooltipVisible = true;
+    
+    // Add global escape key listener
+    document.addEventListener('keydown', handleEscapeKey);
+  }
+
+  function hideTooltip() {
+    if (!tooltipVisible) return;
+    
+    if (tooltipElement) {
+      document.body.removeChild(tooltipElement);
+      trigger.removeAttribute('aria-describedby');
+      tooltipElement = null;
+    }
+    tooltipVisible = false;
+    
+    // Remove global escape key listener
+    document.removeEventListener('keydown', handleEscapeKey);
+  }
+
+  function handleEscapeKey(event) {
+    if (event.key === 'Escape' && tooltipVisible) {
+      event.preventDefault();
+      hideTooltip();
+      // Focus remains on the trigger element - don't move focus
+    }
+  }
+
+  // Event listeners for show/hide
+  trigger.addEventListener('mouseenter', showTooltip);
+  trigger.addEventListener('mouseleave', hideTooltip);
+  trigger.addEventListener('focus', showTooltip);
+  trigger.addEventListener('blur', hideTooltip);
+}
+
+// Initialize all tooltips
+export default function decorate(block) {
+  const tooltips = block.querySelectorAll('.milo-tooltip');
+  tooltips.forEach(initTooltip);
+}
+
+// Auto-initialize tooltips on page load
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => {
+    const tooltips = document.querySelectorAll('.milo-tooltip');
+    tooltips.forEach(tooltip => initTooltip(tooltip.parentElement));
+  });
+} else {
+  const tooltips = document.querySelectorAll('.milo-tooltip');
+  tooltips.forEach(tooltip => initTooltip(tooltip.parentElement));
+}


### PR DESCRIPTION
## Summary
- Fixed: Tooltip is not dismissible without moving mouse hover or keyboard focus
- Change: Added Escape key functionality to dismiss tooltips without moving focus
- Enhanced tooltip JavaScript to include global Escape key listener
- Added proper ARIA attributes and tooltip positioning
- Maintained existing hover and focus behavior while adding keyboard dismissal

## Technical Details
- Added `handleEscapeKey` function that dismisses tooltip on Escape key press
- Tooltip remains visible until dismissed via Escape or focus/mouse moves away
- Focus remains on trigger element when dismissed with Escape (no focus movement)
- Added proper `role="tooltip"` and `aria-describedby` attributes
- Enhanced CSS for better tooltip styling and positioning

## Testing
- [ ] Verified tooltip appears on hover and focus
- [ ] Verified Escape key dismisses tooltip without moving focus
- [ ] Verified tooltip disappears on blur/mouseleave
- [ ] Verified WCAG 1.4.13 Content on Hover or Focus compliance
- [ ] No regressions in existing tooltip functionality

## Related
- Jira: MWPW-176139
- WCAG: 1.4.13 Content on Hover or Focus (Level AA)