### PR TITLE
MWPW-175506: Insufficient color contrast for character counter

### DIFF
--- a/acrobat/blocks/rnr/rnr.css
+++ b/acrobat/blocks/rnr/rnr.css
@@ -125,9 +125,11 @@
 }
 
 .rnr-comments-character-counter {
-  color: var(--color-gray-400);
+
+  color: #767676;
   font-size: 14px;
   font-variant-numeric: tabular-nums;
+
 }
 
 .rnr-summary-container {


### PR DESCRIPTION
## Summary
- Fixed: Insufficient color contrast for character counter text
- Change: Updated color from #B6B6B6 to #767676 for .rnr-comments-character-counter

## Details
- **Element:** `<span class="rnr-comments-character-counter">500 / 500</span>`
- **WCAG Criterion:** 1.4.3 Contrast (Minimum) (Level AA)
- **Previous contrast ratio:** 2:1 (failed)
- **New contrast ratio:** 4.5:1 (passes)
- **Colors:** #767676 on #FFFFFF background

## Testing
- [ ] Verified fix addresses ticket issue
- [ ] Confirmed minimum 4.5:1 contrast ratio is met
- [ ] No regressions in character counter functionality

## Related
- Jira: MWPW-175506