### PR TITLE
MWPW-175506: Insufficient color contrast ratio for character counter

### DIFF
--- a/acrobat/blocks/rnr/rnr.css
+++ b/acrobat/blocks/rnr/rnr.css
@@ -125,9 +125,11 @@
 }
 
 .rnr-comments-character-counter {
-  color: var(--color-gray-400);
+
+  color: #767676;
   font-size: 14px;
   font-variant-numeric: tabular-nums;
+
 }
 
 .rnr-summary-container {


### PR DESCRIPTION
## Summary
- Fixed: Insufficient color contrast ratio for .rnr-comments-character-counter element
- Change: Updated color from #B6B6B6 to #767676 to meet WCAG AA standards

## Testing
- [ ] Verified fix addresses ticket issue
- [ ] No regressions

## Related
- Jira: MWPW-175506
- WCAG: 1.4.3 Contrast (Minimum) (Level AA)

## Details
The character counter text in the RNR comments section had insufficient contrast (2:1 ratio) against the white background. This fix improves the contrast ratio to meet the required 4.5:1 minimum for AA compliance by changing the color from #B6B6B6 to #767676.