### PR TITLE
MWPW-175506: Insufficient color contrast for character counter

### DIFF
--- a/acrobat/blocks/rnr/rnr.css
+++ b/acrobat/blocks/rnr/rnr.css
@@ -125,9 +125,11 @@
 }
 
 .rnr-comments-character-counter {
-  color: var(--color-gray-400);
+
+  color: #767676;
   font-size: 14px;
   font-variant-numeric: tabular-nums;
+
 }
 
 .rnr-summary-container {


### PR DESCRIPTION
## Summary
- Fixed: Insufficient color contrast for character counter in RNR block
- Change: Updated `.rnr-comments-character-counter` color from #B6B6B6 to #767676
- Compliance: Meets WCAG 2.1 Level AA contrast requirements (4.5:1 ratio)

## Details
- **Element**: `<span class="rnr-comments-character-counter">500 / 500</span>`
- **Issue**: Color contrast ratio was 2:1 (below minimum 4.5:1)
- **WCAG**: 1.4.3 Contrast (Minimum) (Level AA)
- **Fix**: Changed color from #B6B6B6 to #767676 for better contrast

## Testing
- [ ] Verified fix addresses ticket issue
- [ ] No regressions
- [ ] Character counter text now meets minimum contrast requirements

## Related
- Jira: MWPW-175506