### PR TITLE
MWPW-175506: Insufficient color contrast ratio for text

### DIFF
--- a/acrobat/blocks/rnr/rnr.css
+++ b/acrobat/blocks/rnr/rnr.css
@@ -125,9 +125,11 @@
 }
 
 .rnr-comments-character-counter {
-  color: var(--color-gray-400);
+
+  color: #767676;
   font-size: 14px;
   font-variant-numeric: tabular-nums;
+
 }
 
 .rnr-summary-container {


### PR DESCRIPTION
## Summary
- Fixed: Insufficient color contrast ratio for .rnr-comments-character-counter text
- Change: Updated color from #B6B6B6 to #767676 to meet WCAG AA requirements

## Details
- **Element**: `<span class="rnr-comments-character-counter">500 / 500</span>`
- **Original color**: #B6B6B6 (contrast ratio 2:1)
- **New color**: #767676 (contrast ratio 4.54:1)
- **WCAG Compliance**: Now meets 1.4.3 Contrast (Minimum) Level AA

## Testing
- [ ] Verified fix addresses ticket issue
- [ ] Contrast ratio now meets 4.5:1 minimum requirement
- [ ] No regressions in character counter functionality

## Related
- Jira: MWPW-175506