### PR TITLE
MWPW-175506: Fix color contrast ratio for character counter

### DIFF
--- a/acrobat/blocks/rnr/rnr.css
+++ b/acrobat/blocks/rnr/rnr.css
@@ -125,9 +125,11 @@
 }
 
 .rnr-comments-character-counter {
-  color: var(--color-gray-400);
+
+  color: #767676;
   font-size: 14px;
   font-variant-numeric: tabular-nums;
+
 }
 
 .rnr-summary-container {


### PR DESCRIPTION
## Summary
- Fixed: Insufficient color contrast ratio for character counter element
- Change: Updated `.rnr-comments-character-counter` color from `var(--color-gray-400)` (#B6B6B6) to `#767676`
- Previous contrast ratio: 2:1 (insufficient)
- New contrast ratio: 4.5:1 (meets WCAG AA standard)

## Testing
- [ ] Verified fix addresses ticket issue
- [ ] No regressions
- [ ] Character counter now meets WCAG 1.4.3 Contrast (Minimum) Level AA

## Related
- Jira: MWPW-175506
- WCAG: 1.4.3 Contrast (Minimum) (Level AA)
- Element: `<span class="rnr-comments-character-counter">500 / 500</span>`