### PR TITLE
MWPW-175506: Insufficient color contrast of text against background

### DIFF
--- a/acrobat/blocks/rnr/rnr.css
+++ b/acrobat/blocks/rnr/rnr.css
@@ -125,9 +125,11 @@
 }
 
 .rnr-comments-character-counter {
-  color: var(--color-gray-400);
+
+  color: #767676;
   font-size: 14px;
   font-variant-numeric: tabular-nums;
+
 }
 
 .rnr-summary-container {


### PR DESCRIPTION
## Summary
- Fixed: Insufficient color contrast of text against background for character counter
- Change: Updated `.rnr-comments-character-counter` color from `var(--color-gray-400)` (#B6B6B6) to `#767676`
- Contrast ratio improved from 2:1 to 4.5:1 (meets WCAG AA minimum)

## Testing
- [ ] Verified fix addresses ticket issue
- [ ] No regressions
- [ ] Character counter now meets WCAG 1.4.3 Contrast (Minimum) Level AA

## Related
- Jira: MWPW-175506
- Element: `<span class="rnr-comments-character-counter">500 / 500</span>`
- WCAG: 1.4.3 Contrast (Minimum) (Level AA)