### PR TITLE
MWPW-175506: Insufficient color contrast for character counter

### DIFF
--- a/acrobat/blocks/rnr/rnr.css
+++ b/acrobat/blocks/rnr/rnr.css
@@ -125,9 +125,11 @@
 }
 
 .rnr-comments-character-counter {
-  color: var(--color-gray-400);
+
+  color: #767676;
   font-size: 14px;
   font-variant-numeric: tabular-nums;
+
 }
 
 .rnr-summary-container {


### PR DESCRIPTION
## Summary
- Fixed: Insufficient color contrast for character counter element
- Change: Updated `.rnr-comments-character-counter` color from #B6B6B6 to #767676
- Previous contrast ratio: 2:1 (below WCAG requirement)
- New contrast ratio: Meets WCAG 4.5:1 minimum requirement

## Testing
- [ ] Verified fix addresses ticket issue
- [ ] Character counter text now has sufficient contrast against white background
- [ ] No regressions in visual appearance
- [ ] WCAG 1.4.3 Contrast (Minimum) Level AA compliance achieved

## Related
- Jira: MWPW-175506
- WCAG: 1.4.3 Contrast (Minimum) (Level AA)