### PR TITLE
MWPW-176136: Make tooltip keyboard accessible for info icon

### DIFF
--- a/libs/blocks/tooltip/tooltip.css
+++ b/libs/blocks/tooltip/tooltip.css
@@ -1,0 +1,75 @@
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.info-icon {
+  cursor: pointer;
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #0066cc;
+  color: white;
+  text-align: center;
+  line-height: 16px;
+  font-size: 12px;
+  font-weight: bold;
+}
+
+.info-icon:focus {
+  outline: 2px solid #0066cc;
+  outline-offset: 2px;
+}
+
+.tooltip-content {
+  position: absolute;
+  background: #333;
+  color: white;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+  white-space: nowrap;
+  z-index: 1000;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s, visibility 0.2s;
+  pointer-events: none;
+}
+
+.tooltip-content.visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+.tooltip-content.right {
+  left: 100%;
+  top: 50%;
+  margin-left: 8px;
+  transform: translateY(-50%);
+}
+
+.tooltip-content.right::before {
+  content: '';
+  position: absolute;
+  right: 100%;
+  top: 50%;
+  margin-top: -4px;
+  border: 4px solid transparent;
+  border-right-color: #333;
+}
+
+.milo-tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.milo-tooltip .info-icon {
+  cursor: pointer;
+  outline: none;
+}
+
+.milo-tooltip .info-icon:focus {
+  outline: 2px solid #0066cc;
+  outline-offset: 2px;
+}

--- a/libs/blocks/tooltip/tooltip.js
+++ b/libs/blocks/tooltip/tooltip.js
@@ -1,0 +1,61 @@
+import { createTag } from '../../utils/utils.js';
+
+export default function init(el) {
+  const tooltip = el.querySelector('.tooltip-content');
+  const trigger = el.querySelector('.info-icon') || el;
+  
+  if (!tooltip) return;
+  
+  // Make tooltip trigger keyboard accessible
+  trigger.setAttribute('tabindex', '0');
+  trigger.setAttribute('role', 'button');
+  trigger.setAttribute('aria-label', 'More information');
+  trigger.setAttribute('aria-expanded', 'false');
+  
+  let isVisible = false;
+  
+  function showTooltip() {
+    tooltip.classList.add('visible');
+    trigger.setAttribute('aria-expanded', 'true');
+    isVisible = true;
+  }
+  
+  function hideTooltip() {
+    tooltip.classList.remove('visible');
+    trigger.setAttribute('aria-expanded', 'false');
+    isVisible = false;
+  }
+  
+  // Mouse events
+  trigger.addEventListener('mouseenter', showTooltip);
+  trigger.addEventListener('mouseleave', hideTooltip);
+  
+  // Keyboard events
+  trigger.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      if (isVisible) {
+        hideTooltip();
+      } else {
+        showTooltip();
+      }
+    } else if (e.key === 'Escape') {
+      hideTooltip();
+      trigger.focus();
+    }
+  });
+  
+  // Focus events
+  trigger.addEventListener('focus', showTooltip);
+  trigger.addEventListener('blur', hideTooltip);
+  
+  // Click events
+  trigger.addEventListener('click', (e) => {
+    e.preventDefault();
+    if (isVisible) {
+      hideTooltip();
+    } else {
+      showTooltip();
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Fixed: Tooltip accessible only on hover, not accessible via keyboard navigation
- Change: Added keyboard support to info icon tooltips with proper ARIA attributes and event handlers

## Changes Made
- Added `tabindex='0'` to make info icon focusable
- Added `role='button'` and `aria-label='More information'` for screen readers
- Added `aria-expanded` attribute to indicate tooltip state
- Implemented keyboard event handlers for Enter/Space (toggle tooltip) and Escape (hide tooltip)
- Added focus/blur event handlers to show/hide tooltip on keyboard focus
- Added proper focus styles with outline for keyboard navigation
- Maintained existing mouse hover functionality

## Testing
- [ ] Verified tooltip can be accessed via keyboard tab navigation
- [ ] Confirmed Enter/Space keys toggle tooltip visibility
- [ ] Verified Escape key hides tooltip and returns focus
- [ ] Tested with screen readers for proper ARIA announcements
- [ ] Confirmed no regressions with mouse hover behavior

## WCAG Compliance
- Addresses WCAG 2.1.1 Keyboard (Level A) - All functionality accessible via keyboard
- Proper focus management and indication
- Screen reader accessible with ARIA attributes

## Related
- Jira: MWPW-176136