### PR TITLE
MWPW-175506: Insufficient color contrast ratio for text

### DIFF
--- a/acrobat/blocks/rnr/rnr.css
+++ b/acrobat/blocks/rnr/rnr.css
@@ -125,9 +125,11 @@
 }
 
 .rnr-comments-character-counter {
-  color: var(--color-gray-400);
+
+  color: #767676;
   font-size: 14px;
   font-variant-numeric: tabular-nums;
+
 }
 
 .rnr-summary-container {


### PR DESCRIPTION
## Summary
- Fixed: Insufficient color contrast ratio for `.rnr-comments-character-counter` text
- Change: Updated color from #B6B6B6 to #767676 to meet WCAG AA contrast requirements

## Details
- **Element**: `<span class="rnr-comments-character-counter">500 / 500</span>`
- **Previous color**: #B6B6B6 (contrast ratio: 2:1)
- **New color**: #767676 (contrast ratio: 4.5:1)
- **WCAG Compliance**: Now meets 1.4.3 Contrast (Minimum) Level AA requirements

## Testing
- [ ] Verified fix addresses ticket contrast issue
- [ ] Confirmed new color meets minimum 4.5:1 contrast ratio
- [ ] No visual regressions in character counter display
- [ ] No functional regressions

## Related
- Jira: MWPW-175506