### PR TITLE
MWPW-176136: Make tooltip info icon keyboard accessible

### DIFF
--- a/libs/blocks/tooltip/tooltip.css
+++ b/libs/blocks/tooltip/tooltip.css
@@ -1,0 +1,70 @@
+/* Enhanced tooltip styles for keyboard accessibility */
+
+.info-icon.milo-tooltip {
+  /* Make focusable elements have visible focus indicator */
+  outline: none;
+  border-radius: 2px;
+  transition: all 0.2s ease;
+}
+
+.info-icon.milo-tooltip:focus {
+  outline: 2px solid #0066cc;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px rgba(0, 102, 204, 0.2);
+}
+
+.info-icon.milo-tooltip:hover,
+.info-icon.milo-tooltip:focus {
+  cursor: pointer;
+}
+
+/* Ensure tooltip content is properly positioned and accessible */
+.info-icon.milo-tooltip .tooltip-content {
+  display: none;
+  position: absolute;
+  z-index: 1000;
+  background: #333;
+  color: white;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+  line-height: 1.4;
+  max-width: 250px;
+  word-wrap: break-word;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.info-icon.milo-tooltip.right .tooltip-content {
+  left: 100%;
+  margin-left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.info-icon.milo-tooltip.tooltip-visible .tooltip-content {
+  display: block;
+}
+
+/* Arrow for tooltip */
+.info-icon.milo-tooltip .tooltip-content::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: -5px;
+  transform: translateY(-50%);
+  border: 5px solid transparent;
+  border-right-color: #333;
+}
+
+/* High contrast mode support */
+@media (prefers-contrast: high) {
+  .info-icon.milo-tooltip:focus {
+    outline: 3px solid;
+    outline-offset: 2px;
+  }
+  
+  .info-icon.milo-tooltip .tooltip-content {
+    background: #000;
+    border: 1px solid #fff;
+  }
+}

--- a/libs/blocks/tooltip/tooltip.js
+++ b/libs/blocks/tooltip/tooltip.js
@@ -1,0 +1,64 @@
+// Enhanced tooltip functionality for keyboard accessibility
+
+// Make tooltip info icons keyboard accessible
+function makeTooltipKeyboardAccessible() {
+  const tooltipIcons = document.querySelectorAll('.info-icon.milo-tooltip');
+  
+  tooltipIcons.forEach(icon => {
+    // Add keyboard accessibility attributes
+    icon.setAttribute('tabindex', '0');
+    icon.setAttribute('role', 'button');
+    icon.setAttribute('aria-label', 'Show tooltip information');
+    
+    // Add keyboard event handlers
+    icon.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        // Show tooltip
+        icon.classList.add('tooltip-visible');
+        const tooltip = icon.querySelector('.tooltip-content');
+        if (tooltip) {
+          tooltip.style.display = 'block';
+          tooltip.setAttribute('aria-hidden', 'false');
+        }
+      }
+      if (e.key === 'Escape') {
+        // Hide tooltip
+        icon.classList.remove('tooltip-visible');
+        const tooltip = icon.querySelector('.tooltip-content');
+        if (tooltip) {
+          tooltip.style.display = 'none';
+          tooltip.setAttribute('aria-hidden', 'true');
+        }
+      }
+    });
+    
+    // Add focus/blur handlers for keyboard navigation
+    icon.addEventListener('focus', () => {
+      icon.classList.add('tooltip-visible');
+      const tooltip = icon.querySelector('.tooltip-content');
+      if (tooltip) {
+        tooltip.style.display = 'block';
+        tooltip.setAttribute('aria-hidden', 'false');
+      }
+    });
+    
+    icon.addEventListener('blur', () => {
+      icon.classList.remove('tooltip-visible');
+      const tooltip = icon.querySelector('.tooltip-content');
+      if (tooltip) {
+        tooltip.style.display = 'none';
+        tooltip.setAttribute('aria-hidden', 'true');
+      }
+    });
+  });
+}
+
+// Initialize on DOM ready
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', makeTooltipKeyboardAccessible);
+} else {
+  makeTooltipKeyboardAccessible();
+}
+
+export default makeTooltipKeyboardAccessible;


### PR DESCRIPTION
## Summary
- Fixed: Tooltip info icon keyboard accessibility issue
- Change: Added keyboard support for tooltip info icons with class 'info-icon milo-tooltip right'

## Changes Made
- Added `tabindex="0"` to make tooltip icons focusable via Tab key
- Added `role="button"` for proper semantic meaning
- Added `aria-label` for accessible name
- Implemented keyboard event handlers for Enter/Space keys to show tooltip
- Added Escape key handler to hide tooltip
- Added focus/blur event handlers for keyboard navigation
- Enhanced CSS with focus indicators and high contrast mode support

## WCAG Compliance
- ✅ WCAG 2.1.1 Keyboard (Level A) - All functionality is now available from keyboard
- ✅ Focus indicators visible for keyboard users
- ✅ Proper ARIA attributes for screen readers

## Testing
- [ ] Verified tooltip can be accessed via Tab key navigation
- [ ] Verified tooltip shows on focus and Enter/Space key press
- [ ] Verified tooltip hides on blur and Escape key
- [ ] Verified focus indicators are visible
- [ ] No regressions in mouse/hover functionality

## Related
- Jira: MWPW-176136