### PR TITLE
MWPW-175506: Insufficient color contrast for character counter text

### DIFF
--- a/acrobat/blocks/rnr/rnr.css
+++ b/acrobat/blocks/rnr/rnr.css
@@ -125,9 +125,11 @@
 }
 
 .rnr-comments-character-counter {
-  color: var(--color-gray-400);
+
+  color: #767676;
   font-size: 14px;
   font-variant-numeric: tabular-nums;
+
 }
 
 .rnr-summary-container {


### PR DESCRIPTION
## Summary
- Fixed: Character counter text color contrast issue in rnr block
- Change: Updated `.rnr-comments-character-counter` color from `#B6B6B6` to `#767676`
- Previous contrast ratio: 2:1 (failed WCAG Level AA)
- New contrast ratio: 4.5:1 (passes WCAG Level AA)

## Testing
- [ ] Verified fix addresses ticket issue
- [ ] No regressions
- [ ] Character counter text is now accessible

## Related
- Jira: MWPW-175506
- WCAG: 1.4.3 Contrast (Minimum) (Level AA)