### PR TITLE
MWPW-175506: Insufficient color contrast ratio for character counter

### DIFF
--- a/acrobat/blocks/rnr/rnr.css
+++ b/acrobat/blocks/rnr/rnr.css
@@ -125,9 +125,11 @@
 }
 
 .rnr-comments-character-counter {
-  color: var(--color-gray-400);
+
+  color: #767676;
   font-size: 14px;
   font-variant-numeric: tabular-nums;
+
 }
 
 .rnr-summary-container {


### PR DESCRIPTION
## Summary
- Fixed: Insufficient color contrast ratio for .rnr-comments-character-counter element
- Change: Updated color from var(--color-gray-400) (#B6B6B6) to #767676
- This improves contrast ratio from 2:1 to 4.54:1, meeting WCAG AA requirements

## Testing
- [ ] Verified fix addresses ticket issue
- [ ] No regressions
- [ ] Character counter text is now accessible with proper contrast

## Related
- Jira: MWPW-175506
- WCAG: 1.4.3 Contrast (Minimum) (Level AA)