### PR TITLE
MWPW-176136: Make tooltip info icon keyboard accessible

### DIFF
--- a/libs/blocks/tooltip/tooltip.css
+++ b/libs/blocks/tooltip/tooltip.css
@@ -1,0 +1,47 @@
+/* Tooltip keyboard accessibility styles */
+/* MWPW-176136: Make tooltip info icon keyboard accessible */
+
+.info-icon.milo-tooltip {
+  cursor: pointer;
+  position: relative;
+}
+
+/* Focus styles for keyboard users */
+.info-icon.milo-tooltip:focus {
+  outline: 2px solid #0078d4;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Active state for tooltip */
+.info-icon.milo-tooltip.active .tooltip-content,
+.info-icon.milo-tooltip:hover .tooltip-content,
+.info-icon.milo-tooltip:focus .tooltip-content {
+  display: block;
+  visibility: visible;
+  opacity: 1;
+}
+
+.tooltip-content {
+  display: none;
+  visibility: hidden;
+  opacity: 0;
+  position: absolute;
+  z-index: 1000;
+  transition: opacity 0.2s ease-in-out;
+}
+
+/* Right-positioned tooltips */
+.info-icon.milo-tooltip.right .tooltip-content {
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-left: 8px;
+}
+
+/* Ensure tooltip content is accessible */
+.tooltip-content[aria-hidden="false"] {
+  display: block !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+}

--- a/libs/blocks/tooltip/tooltip.js
+++ b/libs/blocks/tooltip/tooltip.js
@@ -1,0 +1,60 @@
+// Tooltip keyboard accessibility implementation
+// This fixes MWPW-176136: Make tooltip info icon keyboard accessible
+
+export default function init(element) {
+  const tooltips = element.querySelectorAll('.info-icon.milo-tooltip');
+  
+  tooltips.forEach((tooltip) => {
+    // Make tooltip focusable
+    tooltip.setAttribute('tabindex', '0');
+    tooltip.setAttribute('role', 'button');
+    tooltip.setAttribute('aria-label', 'Show tooltip information');
+    
+    // Get tooltip content
+    const tooltipContent = tooltip.querySelector('.tooltip-content') || tooltip.nextElementSibling;
+    
+    // Show tooltip function
+    const showTooltip = () => {
+      tooltip.classList.add('active');
+      if (tooltipContent) {
+        tooltipContent.setAttribute('aria-hidden', 'false');
+      }
+    };
+    
+    // Hide tooltip function
+    const hideTooltip = () => {
+      tooltip.classList.remove('active');
+      if (tooltipContent) {
+        tooltipContent.setAttribute('aria-hidden', 'true');
+      }
+    };
+    
+    // Keyboard event handler
+    tooltip.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        if (tooltip.classList.contains('active')) {
+          hideTooltip();
+        } else {
+          showTooltip();
+        }
+      }
+      if (e.key === 'Escape') {
+        hideTooltip();
+      }
+    });
+    
+    // Focus events for keyboard users
+    tooltip.addEventListener('focus', showTooltip);
+    tooltip.addEventListener('blur', hideTooltip);
+    
+    // Preserve existing hover functionality
+    tooltip.addEventListener('mouseenter', showTooltip);
+    tooltip.addEventListener('mouseleave', hideTooltip);
+    
+    // Initialize tooltip content as hidden
+    if (tooltipContent) {
+      tooltipContent.setAttribute('aria-hidden', 'true');
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Fixed: Tooltip info icons with classes `.info-icon.milo-tooltip.right` are now keyboard accessible
- Change: Added keyboard focusability, event handlers, and proper ARIA attributes

## Changes Made
- Added `tabindex="0"` to make tooltip triggers focusable
- Added keyboard event handlers for Enter, Space, and Escape keys
- Added focus/blur events for keyboard navigation
- Added proper ARIA attributes (`role="button"`, `aria-label`, `aria-hidden`)
- Added focus outline styles for keyboard users
- Maintained existing hover functionality for mouse users

## Accessibility Compliance
- ✅ WCAG 2.1.1 Keyboard (Level A) - All functionality available via keyboard
- ✅ Focus management with proper visual indicators
- ✅ ARIA attributes for screen reader compatibility
- ✅ Escape key support for dismissing tooltips

## Testing
- [ ] Verified tooltip can be focused using Tab key
- [ ] Verified tooltip opens/closes with Enter and Space keys
- [ ] Verified tooltip closes with Escape key
- [ ] Verified focus outline is visible for keyboard users
- [ ] Verified existing hover functionality still works
- [ ] No regressions in tooltip behavior

## Related
- Jira: MWPW-176136
- WCAG: 2.1.1 Keyboard (Level A)