### PR TITLE
MWPW-175506: Insufficient color contrast ratio for character counter

### DIFF
--- a/acrobat/blocks/rnr/rnr.css
+++ b/acrobat/blocks/rnr/rnr.css
@@ -125,9 +125,11 @@
 }
 
 .rnr-comments-character-counter {
-  color: var(--color-gray-400);
+
+  color: #767676;
   font-size: 14px;
   font-variant-numeric: tabular-nums;
+
 }
 
 .rnr-summary-container {


### PR DESCRIPTION
## Summary
- Fixed: Color contrast ratio for `.rnr-comments-character-counter` element
- Change: Updated color from `#B6B6B6` to `#767676` to meet WCAG AA standards

## Details
- **Issue**: Character counter text had insufficient contrast ratio (2:1)
- **Requirement**: WCAG 1.4.3 Contrast (Minimum) requires 4.5:1 for normal text
- **Solution**: Changed color to #767676 which provides adequate contrast on white background

## Testing
- [ ] Verified fix addresses ticket issue
- [ ] No regressions
- [ ] Color contrast now meets WCAG AA standards

## Related
- Jira: MWPW-175506
- WCAG: 1.4.3 Contrast (Minimum) (Level AA)